### PR TITLE
Add secret config file.

### DIFF
--- a/Advanced Kubernetes Usage/Volumes/secret.yaml
+++ b/Advanced Kubernetes Usage/Volumes/secret.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysql-pass
+data:
+  password: UEFTU1dPUkRTX0lOX1BMQUlOX1RFWFRfQVJFX0JBRF9XRV9XSUxMX1NIT1dfU09NRVRISU5HX01PUkVfU0VDVVJFX0xBVEVS


### PR DESCRIPTION
This secret file fixes the error in Section 3, Lecture 24 where the mysql-pass secretKeyRef can't be found when attempting to start the wordpress deployment using the deployment YAML files in the Volumes directory.

The password is base64-encoded by running the following in a terminal (Ubuntu 16.04 LTS):

`echo -n 'PASSWORDS_IN_PLAIN_TEXT_ARE_BAD_WE_WILL_SHOW_SOMETHING_MORE_SECURE_LATER' | base64`

The secret was created by running:

`kubectl create -f secret.yaml`